### PR TITLE
WakaReadme: switch to cdfmlr's fork

### DIFF
--- a/.github/workflows/WakaReadme.yml
+++ b/.github/workflows/WakaReadme.yml
@@ -4,9 +4,9 @@ on:
   schedule:
     # Runs at 00:00 UTC every day
     - cron: '00 00 * * *'
-#   push:
-#     branches: ["master"]
-# ❌ push -> run this workflow -> push update -> run this workflow -> ...
+  push:
+    branches: ["wakaReadmeCiTest"]
+    # ❌ not master: push -> run this workflow -> push update -> run this workflow -> ...
 
 jobs:
   update-readme:

--- a/.github/workflows/WakaReadme.yml
+++ b/.github/workflows/WakaReadme.yml
@@ -13,7 +13,7 @@ jobs:
     name: Update Readme with Metrics
     runs-on: ubuntu-latest
     steps:
-      - uses: athul/waka-readme@master  # anmol098/waka-readme-stats@master
+      - uses: cdfmlr/waka-readme-stats@master  # anmol098/waka-readme-stats@master
         with:
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/WakaReadme.yml
+++ b/.github/workflows/WakaReadme.yml
@@ -13,7 +13,7 @@ jobs:
     name: Update Readme with Metrics
     runs-on: ubuntu-latest
     steps:
-      - uses: AyushAgnihotri2025/waka-readme-stats@master  # anmol098/waka-readme-stats@master
+      - uses: athul/waka-readme@master  # anmol098/waka-readme-stats@master
         with:
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
switch to https://github.com/cdfmlr/waka-readme-stats

fix errors:

```
TypeError: 'NoneType' object is not subscriptable
sys:1: RuntimeWarning: coroutine 'AsyncClient.get' was never awaited
```
